### PR TITLE
Automatically generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+        - feature
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+    - title: Maintenance 🔧
+      labels:
+        - chore
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,16 +250,18 @@ jobs:
 
       # Build github release
       - name: Build release version
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: ${{ needs.check-version.outputs.version }}
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag_name: ${{ needs.check-version.outputs.version }}
           prerelease: false
-          title: Release ${{ needs.check-version.outputs.version }}
+          name: ${{ needs.check-version.outputs.version }}
+          generate_release_notes: true
       - name: Build release latest
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: latest
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag_name: latest
           prerelease: false
-          title: Latest Release ${{ needs.check-version.outputs.version }}
+          name: Latest ${{ needs.check-version.outputs.version }}
+          generate_release_notes: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,7 @@ The following is a set of guidelines for contributing to VITALam and its package
 [Styleguides](#styleguides)
 
 - [Git Commit Messages](#git-commit-messages)
-
-[Additional Notes](#additional-notes)
-
-- [Issue and Pull Request Labels](#issue-and-pull-request-labels)
+- [Pull Request Labels](#pull-request-labels)
 
 ## Code of Conduct
 
@@ -138,3 +135,17 @@ While the prerequisites above must be satisfied prior to having your pull reques
   - :arrow_up: `:arrow_up:` when upgrading dependencies
   - :arrow_down: `:arrow_down:` when downgrading dependencies
   - :shirt: `:shirt:` when removing linter warnings
+
+### Pull Request Labels
+
+| Label name        | :mag_right:                                    | Description                                                                          |
+| ----------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `breaking-change` | [search][search-digicat-label-breaking-change] | Pull requests that add functionality with incompatible API changes (MAJOR SemVer)    |
+| `feature `        | [search][search-digicat-label-feature]         | Pull requests that add functionality with backwards compatibility (MINOR SemVer)     |
+| `chore`           | [search][search-digicat-label-chore]           | Simple changes or improvements to the code base so it can be worked with more easily |
+| `bug`             | [search][search-digicat-label-bug]             | Pull requests that fix bugs                                                          |
+
+[search-digicat-label-breaking-change]: https://github.com/search?q=is%3Apr+user%3Adigicatapult+label%3Abreaking-change
+[search-digicat-label-feature]: https://github.com/search?q=is%3Apr+user%3Adigicatapult+label%3Afeature
+[search-digicat-label-chore]: https://github.com/search?q=is%3Apr+user%3Adigicatapult+label%3Achore
+[search-digicat-label-bug]: https://github.com/search?q=is%3Apr+user%3Adigicatapult+label%3Abug

--- a/helm/vitalam-identity-service/Chart.yaml
+++ b/helm/vitalam-identity-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: vitalam-identity-service
-appVersion: '0.0.1'
+appVersion: '0.0.2'
 description: A Helm chart for vitalam-identity-service
-version: '0.0.1'
+version: '0.0.2'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/vitalam-identity-service/values.yaml
+++ b/helm/vitalam-identity-service/values.yaml
@@ -16,5 +16,5 @@ config:
 image:
   repository: ghcr.io/digicatapult/vitalam-identity-service
   pullPolicy: IfNotPresent
-  tag: 'v0.0.1'
+  tag: 'v0.0.2'
   pullSecrets: ['ghcr-digicatapult']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/vitalam-identity-service",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/vitalam-identity-service",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^5.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/vitalam-identity-service",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Identity Service for VITALam",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Uses the new [automatic release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) GitHub feature to generate release notes, aka `changelog`, based on PR labels. 

- [x] `release.yml` for changelog config, not to be confused with our existing `release.yml` workflow
- [x] use a different publish release [action](https://github.com/softprops/action-gh-release). The previous action has yet to add automatic release notes, [see here](https://github.com/marvinpinto/actions/issues/312).

Example auto-generated release notes:
![image](https://user-images.githubusercontent.com/40722025/149993433-486caa41-5c5f-4f31-9500-6dd9d44a2cd7.png)
