### PR TITLE
Replace rather than update latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,6 +257,18 @@ jobs:
           prerelease: false
           name: ${{ needs.check-version.outputs.version }}
           generate_release_notes: true
+      - name: Delete release latest
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const { owner, repo } = context.repo
+            try {
+              await github.rest.git.deleteRef({ owner, repo, ref: 'tags/latest' })
+            }
+            catch (err) {
+              if (err.status !== 422) throw err
+            } 
       - name: Build release latest
         uses: softprops/action-gh-release@v1
         with:

--- a/helm/vitalam-identity-service/Chart.yaml
+++ b/helm/vitalam-identity-service/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: vitalam-identity-service
-appVersion: '0.0.2'
+appVersion: '0.0.3'
 description: A Helm chart for vitalam-identity-service
-version: '0.0.2'
+version: '0.0.3'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/vitalam-identity-service/values.yaml
+++ b/helm/vitalam-identity-service/values.yaml
@@ -17,5 +17,5 @@ config:
 image:
   repository: ghcr.io/digicatapult/vitalam-identity-service
   pullPolicy: IfNotPresent
-  tag: 'v0.0.2'
+  tag: 'v0.0.3'
   pullSecrets: ['ghcr-digicatapult']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/vitalam-identity-service",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/vitalam-identity-service",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^5.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/vitalam-identity-service",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Identity Service for VITALam",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Uses [github-script](https://github.com/actions/github-script) to delete `tags/latest` so we get a new `latest` release that matches our most recent release.